### PR TITLE
libarchive code has moved from google to github

### DIFF
--- a/archive.doc
+++ b/archive.doc
@@ -21,7 +21,7 @@
 \maketitle
 
 \begin{abstract}
-The library \url[libarchive]{http://code.google.com/p/libarchive/}
+The library \url[libarchive]{https://github.com/libarchive/libarchive}
 provides a portable way to access archive files as well as encoded
 (typically compressed) data. This package is a Prolog wrapper around
 this library. The motivation to introduce this library is twofold. In
@@ -68,7 +68,7 @@ Windows and the .cab format is rare outside the Windows context.
 Discarding availability of archive programs, each archive program comes
 with its own set of command line options and its own features and
 limitations. Fortunately,
-\url[libarchive]{http://code.google.com/p/libarchive/} provides a
+\url[libarchive]{https://github.com/libarchive/libarchive} provides a
 consistent interface to a wealth of compression and archiving formats.
 The library \pllib{archive} wraps this library, providing access to
 archives using Prolog streams both for the archive as a whole and the


### PR DESCRIPTION
changing URL to https://github.com/libarchive/libarchive
