### PR TITLE
FIXED: In archive_data_stream/3 options must be applied recursively.

### DIFF
--- a/archive.pl
+++ b/archive.pl
@@ -121,16 +121,23 @@ archive_open(Stream, Archive, Options) :-
 %     and =xz=. The value =all= is default for read, =none= for write.
 %
 %     * format(+Format)
-%     Support the indicated format.  This option may be used
-%     multiple times to support multiple formats in read mode.
-%     In write mode, you must supply a single format. If no format
-%     options are provided, =all= is assumed for read mode. Note that
-%     =all= does *not* include =raw=. To open both archive
-%     and non-archive files, _both_ format(all) and
-%     format(raw) must be specified. Supported values are: =all=,
-%     =7zip=, =ar=, =cab=, =cpio=, =empty=, =gnutar=, =iso9660=,
-%     =lha=, =mtree=, =rar=, =raw=, =tar=, =xar= and =zip=. The
-%     value =all= is default for read.
+%     Support the indicated format. This  option   may  be used multiple
+%     times to support multiple formats in read mode. In write mode, you
+%     must supply a single format. If   no  format options are provided,
+%     =all= is assumed for read mode. Note that =all= does *not* include
+%     =raw=.  To  open  both  archive   and  non-archive  files,  _both_
+%     format(all) and format(raw) must be specified.
+%
+%     In read mode, the following values   are supported: =all=, =7zip=,
+%     =ar=, =cab=, =cpio=, =empty=, =gnutar=, =iso9660=, =lha=, =mtree=,
+%     =rar=, =raw=, =tar=, =xar= and =zip=.   The value =all= is default
+%     for read.
+%
+%     In write mode the following formats are supported: =7zip=, =cpio=,
+%     =gnutar=, =iso9660=, =xar= and =zip=.
+%
+%     Note that a particular installation may   support only a subset of
+%     these, depending on the configuration of =libarchive=.
 %
 %   Note that the actually supported   compression types and formats
 %   may vary depending on the version   and  installation options of

--- a/archive4pl.c
+++ b/archive4pl.c
@@ -637,11 +637,11 @@ archive_open_stream(term_t data, term_t mode, term_t handle, term_t options)
 	ar->type |= FORMAT_7ZIP;
 #endif
 #ifdef FORMAT_AR
-      else if ( f == ATOM_ar )
+      else if ( how == 'r' && f == ATOM_ar )
 	ar->type |= FORMAT_AR;
 #endif
 #ifdef FORMAT_CAB
-      else if ( f == ATOM_cab )
+      else if ( how == 'r' && f == ATOM_cab )
 	ar->type |= FORMAT_CAB;
 #endif
 #ifdef FORMAT_CPIO
@@ -649,7 +649,7 @@ archive_open_stream(term_t data, term_t mode, term_t handle, term_t options)
 	ar->type |= FORMAT_CPIO;
 #endif
 #ifdef FORMAT_EMPTY
-      else if ( f == ATOM_empty )
+      else if ( how == 'r' && f == ATOM_empty )
 	ar->type |= FORMAT_EMPTY;
 #endif
 #ifdef FORMAT_GNUTAR
@@ -661,23 +661,23 @@ archive_open_stream(term_t data, term_t mode, term_t handle, term_t options)
 	ar->type |= FORMAT_ISO9660;
 #endif
 #ifdef FORMAT_LHA
-      else if ( f == ATOM_lha )
+      else if ( how == 'r' && f == ATOM_lha )
 	ar->type |= FORMAT_LHA;
 #endif
 #ifdef FORMAT_MTREE
-      else if ( f == ATOM_mtree )
+      else if ( how == 'r' && f == ATOM_mtree )
 	ar->type |= FORMAT_MTREE;
 #endif
 #ifdef FORMAT_RAR
-      else if ( f == ATOM_rar )
+      else if ( how == 'r' && f == ATOM_rar )
 	ar->type |= FORMAT_RAR;
 #endif
 #ifdef FORMAT_RAW
-      else if ( f == ATOM_raw )
+      else if ( how == 'r' && f == ATOM_raw )
 	ar->type |= FORMAT_RAW;
 #endif
 #ifdef FORMAT_TAR
-      else if ( f == ATOM_tar )
+      else if ( how == 'r' && f == ATOM_tar )
 	ar->type |= FORMAT_TAR;
 #endif
 #ifdef FORMAT_XAR
@@ -689,7 +689,10 @@ archive_open_stream(term_t data, term_t mode, term_t handle, term_t options)
 	ar->type |= FORMAT_ZIP;
 #endif
       else
-	return PL_domain_error("format", arg);
+	if ( how == 'r' )
+          return PL_domain_error("read_format", arg);
+	else
+          return PL_domain_error("write_format", arg);
     } else if ( name == ATOM_close_parent )
     { if ( !PL_get_bool_ex(arg, &ar->close_parent) )
 	return FALSE;


### PR DESCRIPTION
In archive_data_stream/3, the specification of filter/1 and format/1
options would only apply to the outer archive, but not to any of the
inner archive.  This caused the following two concrete problems:

  1. archive_data_stream/3 could not be used to decompress an archive
     partially.  E.g., unpack the outer TAR and GNU zip layers, but
     keep the inner ZIP filter compressed.

  2. archive_data_stream/3 would often return mtree errors when
     unpacking inner layers, even when the mtree format was not
     specified through a format/1 option.  Since mtree is basically a
     simple text format, it must be included when unpacking archives
     of arbitrary depth and with arbitrary content.  This can only be
     achieved if the supplies format/1 options are passed recursively.